### PR TITLE
provide more control over plot location

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ To change the backend in matplotlib,
    matplotlib.use("module://matplotlib_pyodide.html5_canvas_backend")
    ```
 
+By default, matplotlib figures will be rendered inside a div that's appended to the end of `document.body`. 
+You can override this behavior by setting `document.pyodideMplTarget` to an HTML element. If you had an HTML 
+element with id "target", you could configure the backend to render visualizations inside it with this code:
+
+```py
+document.pyodideMplTarget = document.getElementById('target')
+```
+
 For more information see the [matplotlib documentation](https://matplotlib.org/stable/users/explain/backends.html).
 
 ## License

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ To change the backend in matplotlib,
    matplotlib.use("module://matplotlib_pyodide.html5_canvas_backend")
    ```
 
-By default, matplotlib figures will be rendered inside a div that's appended to the end of `document.body`. 
-You can override this behavior by setting `document.pyodideMplTarget` to an HTML element. If you had an HTML 
+By default, matplotlib figures will be rendered inside a div that's appended to the end of `document.body`.
+You can override this behavior by setting `document.pyodideMplTarget` to an HTML element. If you had an HTML
 element with id "target", you could configure the backend to render visualizations inside it with this code:
 
 ```py

--- a/matplotlib_pyodide/browser_backend.py
+++ b/matplotlib_pyodide/browser_backend.py
@@ -312,8 +312,8 @@ class FigureCanvasWasm(FigureCanvasBase):
     }
 
     def _create_root_element(self):
-        div = document.createElement('div')
-        mpl_target = getattr(document, 'pyodideMplTarget', document.body)
+        div = document.createElement("div")
+        mpl_target = getattr(document, "pyodideMplTarget", document.body)
         mpl_target.appendChild(div)
         return div
 

--- a/matplotlib_pyodide/browser_backend.py
+++ b/matplotlib_pyodide/browser_backend.py
@@ -90,10 +90,6 @@ class FigureCanvasWasm(FigureCanvasBase):
         )
         return DEVICE_PIXEL_RATIO / backing_store
 
-    def create_root_element(self):
-        # Designed to be overridden by subclasses
-        return document.createElement("div")
-
     def show(self):
         # If we've already shown this canvas elsewhere, don't create a new one,
         # just reuse it and scroll to the existing one.
@@ -118,7 +114,7 @@ class FigureCanvasWasm(FigureCanvasBase):
         width, height = self.get_width_height()
         width *= self._ratio
         height *= self._ratio
-        div = self.create_root_element()
+        div = self._create_root_element()
         add_event_listener(div, "contextmenu", ignore)
         div.setAttribute(
             "style",
@@ -314,6 +310,12 @@ class FigureCanvasWasm(FigureCanvasBase):
         221: "]",
         222: "'",
     }
+
+    def _create_root_element(self):
+        div = document.createElement('div')
+        mpl_target = getattr(document, 'pyodideMplTarget', document.body)
+        mpl_target.appendChild(div)
+        return div
 
     def _convert_key_event(self, event):
         code = int(event.which)

--- a/matplotlib_pyodide/html5_canvas_backend.py
+++ b/matplotlib_pyodide/html5_canvas_backend.py
@@ -44,11 +44,6 @@ class FigureCanvasHTMLCanvas(FigureCanvasWasm):
     def __init__(self, *args, **kwargs):
         FigureCanvasWasm.__init__(self, *args, **kwargs)
 
-    def create_root_element(self):
-        root_element = document.createElement("div")
-        document.body.appendChild(root_element)
-        return root_element
-
     def draw(self):
         # Render the figure using custom renderer
         self._idle_scheduled = True


### PR DESCRIPTION
This starts to address issue #19. I realize I'm still missing tests, but I wanted to get something here for starters. Am I right to assume that we want to use pytest and pytest-pyodide here? (issue #3 suggests pytest is our testing tool of choice.)

The new behavior is documented in `README.md` and reproduced here for convenience:

By default, matplotlib figures will be rendered inside a div that's appended to the end of `document.body`. 
You can override this behavior by setting `document.pyodideMplTarget` to an HTML element. If you had an HTML 
element with id "target", you could configure the backend to render visualizations inside it with this code:

```py
document.pyodideMplTarget = document.getElementById('target')
```