### PR TITLE
CI Update Python and Pyodide versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
-        pyodide-version: [0.21.3, 0.22.0a3]
+        os: [ubuntu-latest]
+        pyodide-version: [0.23.4]
         test-config: [
           {runner: selenium, runtime: chrome, runtime-version: latest},
         ]
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.10.2
+          python-version: 3.11
 
       - uses: pyodide/pyodide-actions/download-pyodide@v1
         with:
@@ -67,7 +67,7 @@ jobs:
 
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.10.2
+          python-version: 3.11
       - name: Install requirements and build wheel
         shell: bash -l {0}
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
 test = [
-  "pytest-pyodide==0.23.1",
+  "pytest-pyodide==0.52.2",
   "pytest-cov",
   "build",
 ]


### PR DESCRIPTION
Fixes failed deployment: https://github.com/pyodide/matplotlib-pyodide/actions/runs/5999124043.

(I removed the tag and will push it again)