### PR TITLE
Bump Pyodide version, Python version, and other cleanups

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,17 +18,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        pyodide-version: [0.25.0]
+        pyodide-version: [0.26.4]
         test-config: [
           {runner: selenium, runtime: chrome, runtime-version: latest},
         ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - uses: pyodide/pyodide-actions/download-pyodide@v1
         with:
@@ -63,11 +63,11 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     environment: PyPi-deploy
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.12
       - name: Install requirements and build wheel
         shell: bash -l {0}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,8 @@ jobs:
         os: [ubuntu-latest]
         pyodide-version: [0.26.4]
         test-config: [
-          {runner: selenium, runtime: chrome, runtime-version: latest},
+          # FIXME: timeouts on recent versions of Chrome, same as micropip
+          {runner: selenium, runtime: chrome, runtime-version: 125},
         ]
 
     steps:
@@ -40,7 +41,7 @@ jobs:
           version: ${{ matrix.pyodide-version }}
           to: dist
 
-      - uses: pyodide/pyodide-actions/install-browser@v1
+      - uses: pyodide/pyodide-actions/install-browser@v2
         with:
           runner: ${{ matrix.test-config.runner }}
           browser: ${{ matrix.test-config.runtime }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ name: main
 
 on: [push, pull_request]
 
+env:
+  FORCE_COLOR: 3
+
 permissions:
   contents: read
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ known_first_party = [
 ]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.12"
 show_error_codes = true
 warn_unreachable = true
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,13 @@ authors = [
 ]
 description = "HTML5 backends for Matplotlib compatible with Pyodide"
 readme = "README.md"
-license = { file="LICENSE" }
 requires-python = ">=3.10"
+license = { file = "LICENSE" }
 dynamic = ["version"]
 classifiers = [
-    "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
-    "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
+  "Operating System :: OS Independent",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ authors = [
 ]
 description = "HTML5 backends for Matplotlib compatible with Pyodide"
 readme = "README.md"
-requires-python = ">=3.10"
 license = { file = "LICENSE" }
+requires-python = ">=3.12"
 dynamic = ["version"]
 classifiers = [
   "Programming Language :: Python :: 3",
@@ -15,7 +15,7 @@ classifiers = [
 ]
 
 [build-system]
-requires = ["setuptools>=42", "setuptools_scm[toml]>=6.2", "wheel"]
+requires = ["setuptools>=71", "setuptools_scm[toml]>=6.2"]
 
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Related to #60. We can now use Python 3.12 and later for building for for Mypy checks; `setuptools` injects `wheel` when building wheels, so `wheel` is not required as a build-time dependency anymore; and some bumps to versions for a few GitHub Actions.