### PR TITLE
Add testing on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
         pyodide-version: [0.26.4]
         test-config:
           [


### PR DESCRIPTION
At the time of opening, this is going to fail as it did in [this workflow run](https://github.com/pyodide/matplotlib-pyodide/actions/runs/12083017969/job/33695309855), but it looks like an easy fix in https://github.com/pyodide/pyodide-actions/. This does not need to block a release, and I shall test out a patch for the action in my fork of it first.